### PR TITLE
Eval mode for ASR model and compatibility with PyTorch > 1.7

### DIFF
--- a/Utils/ASR/layers.py
+++ b/Utils/ASR/layers.py
@@ -77,7 +77,7 @@ class CausualConv(nn.Module):
         return x
 
 class CausualBlock(nn.Module):
-    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ='lrelu'):
+    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.0, activ='lrelu'):
         super(CausualBlock, self).__init__()
         self.blocks = nn.ModuleList([
             self._get_conv(hidden_dim, dilation=3**i, activ=activ, dropout_p=dropout_p)
@@ -90,7 +90,7 @@ class CausualBlock(nn.Module):
             x += res
         return x
 
-    def _get_conv(self, hidden_dim, dilation, activ='lrelu', dropout_p=0.2):
+    def _get_conv(self, hidden_dim, dilation, activ='lrelu', dropout_p=0.0):
         layers = [
             CausualConv(hidden_dim, hidden_dim, kernel_size=3, padding=dilation, dilation=dilation),
             _get_activation_fn(activ),
@@ -103,7 +103,7 @@ class CausualBlock(nn.Module):
         return nn.Sequential(*layers)
 
 class ConvBlock(nn.Module):
-    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ='relu'):
+    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.0, activ='relu'):
         super().__init__()
         self._n_groups = 8
         self.blocks = nn.ModuleList([
@@ -118,7 +118,7 @@ class ConvBlock(nn.Module):
             x += res
         return x
 
-    def _get_conv(self, hidden_dim, dilation, activ='relu', dropout_p=0.2):
+    def _get_conv(self, hidden_dim, dilation, activ='relu', dropout_p=0.0):
         layers = [
             ConvNorm(hidden_dim, hidden_dim, kernel_size=3, padding=dilation, dilation=dilation),
             _get_activation_fn(activ),

--- a/Utils/ASR/layers.py
+++ b/Utils/ASR/layers.py
@@ -87,7 +87,7 @@ class CausualBlock(nn.Module):
         for block in self.blocks:
             res = x
             x = block(x)
-            x += res
+            x = x + res
         return x
 
     def _get_conv(self, hidden_dim, dilation, activ='lrelu', dropout_p=0.0):
@@ -115,7 +115,7 @@ class ConvBlock(nn.Module):
         for block in self.blocks:
             res = x
             x = block(x)
-            x += res
+            x = x + res
         return x
 
     def _get_conv(self, hidden_dim, dilation, activ='relu', dropout_p=0.0):


### PR DESCRIPTION
- Removed the inplace operation in Residual connection by replacing x+=res with x = x + res to make the repository compatible with torch > 1.7 
- Modified the dropout to be 0 in ASR to put it in eval mode